### PR TITLE
Weapon Modifications Amends Part 1

### DIFF
--- a/amend_weapons.xml
+++ b/amend_weapons.xml
@@ -272,14 +272,24 @@
         </weapon>
         <weapon> <!-- Microwave Gun, High Frequency -->
             <id>21fb8d4f-5958-4fd9-996f-7e88ee0282c2</id>
-            <accessorymounts>		
-                <mount amendoperation="addnode">Hub Internal</mount>
+            <allowaccessory amendoperation="remove">False</allowaccessory>
+            <accessorymounts amendoperation="addnode">
+                <mount>Top</mount>
+                <mount>Side</mount>
+                <mount>Under</mount>
+                <mount>Stock</mount>
+                <mount>Hub Internal</mount>
             </accessorymounts>
         </weapon>
         <weapon> <!-- Microwave Gun, Low Frequency -->
             <id>10fb69db-efd0-4f63-80a7-bda5ef0480a4</id>
-            <accessorymounts>		
-                <mount amendoperation="addnode">Hub Internal</mount>
+            <allowaccessory amendoperation="remove">False</allowaccessory>
+            <accessorymounts amendoperation="addnode">
+                <mount>Top</mount>
+                <mount>Side</mount>
+                <mount>Under</mount>
+                <mount>Stock</mount>
+                <mount>Hub Internal</mount>
             </accessorymounts>
         </weapon>
     </weapons>

--- a/amend_weapons.xml
+++ b/amend_weapons.xml
@@ -121,9 +121,41 @@
                 <mount amendoperation="addnode">Hub Internal</mount>
             </accessorymounts>
         </weapon>
-        <weapon xpathfilter="category='Crossbows'">
-            <accessorymounts>		
-                <mount amendoperation="addnode">Hub Internal</mount>
+    </weapons>
+    <weapons> <!-- Crossbows -->
+        <weapon> <!-- Light Crossbow -->
+            <id>bc9db3ec-6fa2-407d-ad76-e49daac3c06f</id>
+            <accessorymounts amendoperation="addnode">
+                <mount>Top</mount>
+                <mount>Side</mount>
+                <mount>Stock</mount>		
+                <mount>Hub Internal</mount>
+            </accessorymounts>
+        </weapon>
+        <weapon> <!-- Medium Crossbow -->
+            <id>0df17331-7631-4f78-b857-0f3929678db2</id>
+            <accessorymounts amendoperation="addnode">
+                <mount>Top</mount>
+                <mount>Side</mount>
+                <mount>Stock</mount>		
+                <mount>Hub Internal</mount>
+            </accessorymounts>
+        </weapon>
+        <weapon> <!-- Heavy Crossbow -->
+            <id>db213a06-0430-4711-81a3-5790d5152ba3</id>
+            <accessorymounts amendoperation="addnode">
+                <mount>Top</mount>
+                <mount>Side</mount>
+                <mount>Stock</mount>		
+                <mount>Hub Internal</mount>
+            </accessorymounts>
+        </weapon>
+        <weapon> <!-- Ranger Sliver Pistol Crossbow -->
+            <id>28072a3f-5153-444e-83e3-46129b9ff572</id>
+            <accessorymounts amendoperation="addnode">
+                <mount>Top</mount>
+                <mount>Side</mount>		
+                <mount>Hub Internal</mount>
             </accessorymounts>
         </weapon>
     </weapons>
@@ -194,14 +226,22 @@
         </weapon>
         <weapon> <!-- Aquadyne Shark-XS Harpoon Gun -->
             <id>a20f44a1-ced0-4018-9522-8a0e7234c29d</id>
-            <accessorymounts>		
-                <mount amendoperation="addnode">Hub Internal</mount>
+            <accessorymounts amendoperation="addnode">
+                <mount>Top</mount>
+                <mount>Side</mount>
+                <mount>Under</mount>
+                <mount>Stock</mount>		
+                <mount>Hub Internal</mount>
             </accessorymounts>
         </weapon>
         <weapon> <!-- Standard Harpoon Gun -->
             <id>d50f0212-490b-44ca-8365-09e62ea69697</id>
-            <accessorymounts>		
-                <mount amendoperation="addnode">Hub Internal</mount>
+            <accessorymounts amendoperation="addnode">
+                <mount>Top</mount>
+                <mount>Side</mount>
+                <mount>Under</mount>
+                <mount>Stock</mount>		
+                <mount>Hub Internal</mount>
             </accessorymounts>
         </weapon>
         <weapon> <!-- Ares Armatus -->

--- a/amend_weapons.xml
+++ b/amend_weapons.xml
@@ -42,86 +42,6 @@
     <!-- Chummer treats Internal slot as None, so create custom Internal mount and apply to all guns that should have one -->
     <!-- Also apply missing mounts for Individual Weapons -->
     <weapons> <!-- Weapon Categories -->
-        <weapon xpathfilter="category='Tasers'">
-            <accessorymounts>		
-                <mount amendoperation="addnode">Hub Internal</mount>
-            </accessorymounts>
-        </weapon>
-        <weapon xpathfilter="category='Light Pistols'">
-            <accessorymounts>		
-                <mount amendoperation="addnode">Hub Internal</mount>
-            </accessorymounts>
-        </weapon>
-        <weapon xpathfilter="category='Heavy Pistols'">
-            <accessorymounts>		
-                <mount amendoperation="addnode">Hub Internal</mount>
-            </accessorymounts>
-        </weapon>
-        <weapon xpathfilter="category='Machine Pistols'">
-            <accessorymounts>		
-                <mount amendoperation="addnode">Hub Internal</mount>
-            </accessorymounts>
-        </weapon>
-        <weapon xpathfilter="category='Submachine Guns'">
-            <accessorymounts>		
-                <mount amendoperation="addnode">Hub Internal</mount>
-            </accessorymounts>
-        </weapon>
-        <weapon xpathfilter="category='Assault Rifles'">
-            <accessorymounts>		
-                <mount amendoperation="addnode">Hub Internal</mount>
-            </accessorymounts>
-        </weapon>
-        <weapon xpathfilter="category='Carbines'">
-            <accessorymounts>		
-                <mount amendoperation="addnode">Hub Internal</mount>
-            </accessorymounts>
-        </weapon>
-        <weapon xpathfilter="category='Sporting Rifles'">
-            <accessorymounts>		
-                <mount amendoperation="addnode">Hub Internal</mount>
-            </accessorymounts>
-        </weapon>
-        <weapon xpathfilter="category='Sniper Rifles'">
-            <accessorymounts>		
-                <mount amendoperation="addnode">Hub Internal</mount>
-            </accessorymounts>
-        </weapon>
-        <weapon xpathfilter="category='Shotguns'">
-            <accessorymounts>		
-                <mount amendoperation="addnode">Hub Internal</mount>
-            </accessorymounts>
-        </weapon>
-        <weapon xpathfilter="category='Light Machine Guns'">
-            <accessorymounts>		
-                <mount amendoperation="addnode">Hub Internal</mount>
-            </accessorymounts>
-        </weapon>
-        <weapon xpathfilter="category='Medium Machine Guns'">
-            <accessorymounts>		
-                <mount amendoperation="addnode">Hub Internal</mount>
-            </accessorymounts>
-        </weapon>
-        <weapon xpathfilter="category='Heavy Machine Guns'">
-            <accessorymounts>		
-                <mount amendoperation="addnode">Hub Internal</mount>
-            </accessorymounts>
-        </weapon>
-        <weapon xpathfilter="category='Assault Cannons'">
-            <accessorymounts>		
-                <mount amendoperation="addnode">Hub Internal</mount>
-            </accessorymounts>
-        </weapon>
-        <weapon xpathfilter="category='Grenade Launchers'">
-            <accessorymounts>		
-                <mount amendoperation="addnode">Hub Internal</mount>
-            </accessorymounts>
-        </weapon>
-        <weapon xpathfilter="category='Missile Launchers'">
-            <accessorymounts>		
-                <mount amendoperation="addnode">Hub Internal</mount>
-            </accessorymounts>
-        </weapon>
         <weapon xpathfilter="category='Flamethrowers'">
             <accessorymounts amendoperation="replace" addifnotfound="True">
                 <mount>Top</mount>
@@ -136,8 +56,7 @@
             <accessorymounts amendoperation="addnode">
                 <mount>Top</mount>
                 <mount>Side</mount>
-                <mount>Stock</mount>		
-                <mount>Hub Internal</mount>
+                <mount>Stock</mount>
             </accessorymounts>
         </weapon>
         <weapon> <!-- Medium Crossbow -->
@@ -145,8 +64,7 @@
             <accessorymounts amendoperation="addnode">
                 <mount>Top</mount>
                 <mount>Side</mount>
-                <mount>Stock</mount>		
-                <mount>Hub Internal</mount>
+                <mount>Stock</mount>
             </accessorymounts>
         </weapon>
         <weapon> <!-- Heavy Crossbow -->
@@ -154,66 +72,32 @@
             <accessorymounts amendoperation="addnode">
                 <mount>Top</mount>
                 <mount>Side</mount>
-                <mount>Stock</mount>		
-                <mount>Hub Internal</mount>
+                <mount>Stock</mount>
             </accessorymounts>
         </weapon>
         <weapon> <!-- Ranger Sliver Pistol Crossbow -->
             <id>28072a3f-5153-444e-83e3-46129b9ff572</id>
             <accessorymounts amendoperation="addnode">
                 <mount>Top</mount>
-                <mount>Side</mount>		
-                <mount>Hub Internal</mount>
+                <mount>Side</mount>
             </accessorymounts>
         </weapon>
     </weapons>
     <weapons> <!-- Pistol Sized Individual Ranged Weapons -->
-        <weapon> <!-- Parashield Dart Pistol -->
-            <id>9c3d9b2e-336e-4c37-b05d-07bea9ae9c3f</id>
-            <accessorymounts>		
-                <mount amendoperation="addnode">Hub Internal</mount>
-            </accessorymounts>
-        </weapon>
-        <weapon> <!-- Ares Redline -->
-            <id>78293136-5bd0-49ac-aa9b-7c291f94c7a4</id>
-            <accessorymounts>		
-                <mount amendoperation="addnode">Hub Internal</mount>
-            </accessorymounts>
-        </weapon>
         <weapon> <!-- FN-AAL Gyrojet Pistol -->
             <id>a836fc0b-a1e1-491d-ad8d-7f803c88acdc</id>
             <accessorymounts>		
                 <mount amendoperation="addnode">Barrel</mount>
-                <mount amendoperation="addnode">Hub Internal</mount>
-            </accessorymounts>
-        </weapon>
-        <weapon> <!-- Narcoject Gas Gun -->
-            <id>39a6ea40-087e-4caa-b5a5-94d7c2a203f3</id>
-            <accessorymounts>		
-                <mount amendoperation="addnode">Hub Internal</mount>
-            </accessorymounts>
-        </weapon>
-        <weapon> <!-- Narcoject Trackstopper -->
-            <id>823ffbe6-b8a9-43f6-91e1-ba3e312ce577</id>
-            <accessorymounts>		
-                <mount amendoperation="addnode">Hub Internal</mount>
             </accessorymounts>
         </weapon>
     </weapons>
     <weapons> <!-- Submachine Gun Sized Individual Ranged Weapons -->    
-        <weapon> <!-- Ares Lancer MP Laser -->
-            <id>d6c4ff4a-5fbb-4885-9220-a784e2bff4f4</id>
-            <accessorymounts>		
-                <mount amendoperation="addnode">Hub Internal</mount>
-            </accessorymounts>
-        </weapon>
         <weapon> <!-- Grapple Gun -->
             <id>9c267b03-103e-43f4-bfe8-986c69dc17d2</id>
             <accessorymounts amendoperation="addnode">		
                 <mount>Top</mount>
                 <mount>Side</mount>
                 <mount>Stock</mount>
-                <mount>Hub Internal</mount>
             </accessorymounts>
         </weapon>
         <weapon> <!-- Tactical Grapple Gun -->
@@ -222,31 +106,17 @@
                 <mount>Top</mount>
                 <mount>Side</mount>
                 <mount>Stock</mount>
-                <mount>Hub Internal</mount>
             </accessorymounts>
         </weapon>
     </weapons>
     <weapons> <!-- Assault Rifle Sized Individual Ranged Weapons --> 
-        <weapon> <!-- Ares S-III Super Squirt -->
-            <id>15ec7fbb-4c22-4cae-a7cd-d2c580a6b447</id>
-            <accessorymounts>		
-                <mount amendoperation="addnode">Hub Internal</mount>
-            </accessorymounts>
-        </weapon>
-        <weapon> <!-- Fichetti Pain Inducer -->
-            <id>c884cf55-9a96-459d-a764-f223e1853149</id>
-            <accessorymounts>		
-                <mount amendoperation="addnode">Hub Internal</mount>
-            </accessorymounts>
-        </weapon>
         <weapon> <!-- Aquadyne Shark-XS Harpoon Gun -->
             <id>a20f44a1-ced0-4018-9522-8a0e7234c29d</id>
             <accessorymounts amendoperation="addnode">
                 <mount>Top</mount>
                 <mount>Side</mount>
                 <mount>Under</mount>
-                <mount>Stock</mount>		
-                <mount>Hub Internal</mount>
+                <mount>Stock</mount>
             </accessorymounts>
         </weapon>
         <weapon> <!-- Standard Harpoon Gun -->
@@ -255,26 +125,7 @@
                 <mount>Top</mount>
                 <mount>Side</mount>
                 <mount>Under</mount>
-                <mount>Stock</mount>		
-                <mount>Hub Internal</mount>
-            </accessorymounts>
-        </weapon>
-        <weapon> <!-- Ares Armatus -->
-            <id>176ab92a-0c00-48fe-a994-668903407fbf</id>
-            <accessorymounts>		
-                <mount amendoperation="addnode">Hub Internal</mount>
-            </accessorymounts>
-        </weapon>
-        <weapon> <!-- Ares Screech Sonic Rifle -->
-            <id>e85d55b3-06f1-48e0-bbe1-14b833ac4181</id>
-            <accessorymounts>		
-                <mount amendoperation="addnode">Hub Internal</mount>
-            </accessorymounts>
-        </weapon>
-        <weapon> <!-- Repeating Laser -->
-            <id>bb17f788-f4d2-4a32-a758-2ed47a1beb63</id>
-            <accessorymounts>		
-                <mount amendoperation="addnode">Hub Internal</mount>
+                <mount>Stock</mount>
             </accessorymounts>
         </weapon>
         <weapon> <!-- Microwave Gun, High Frequency -->
@@ -285,7 +136,6 @@
                 <mount>Side</mount>
                 <mount>Under</mount>
                 <mount>Stock</mount>
-                <mount>Hub Internal</mount>
             </accessorymounts>
         </weapon>
         <weapon> <!-- Microwave Gun, Low Frequency -->
@@ -296,40 +146,22 @@
                 <mount>Side</mount>
                 <mount>Under</mount>
                 <mount>Stock</mount>
-                <mount>Hub Internal</mount>
             </accessorymounts>
         </weapon>
     </weapons>
-    <weapons> <!-- Sniper Sized Individual Ranged Weapons -->
-        <weapon> <!-- Parashield Dart Rifle -->
-            <id>8432b006-0496-4930-b966-25ab56feb7e2</id>
-            <accessorymounts>		
-                <mount amendoperation="addnode">Hub Internal</mount>
-            </accessorymounts>
-        </weapon>
-        <weapon> <!-- Ares Archon Heavy MP Laser -->
-            <id>df5d5c83-ddf8-4ec2-8a6f-28c61ec7325a</id>
-            <accessorymounts>		
-                <mount amendoperation="addnode">Hub Internal</mount>
-            </accessorymounts>
-        </weapon>
-        <weapon> <!-- Ares Thunderstruck Gauss Rifle -->
-            <id>e5ac06f4-3755-42a7-9da9-88de4b3b2ad8</id>
-            <accessorymounts>		
-                <mount amendoperation="addnode">Hub Internal</mount>
-            </accessorymounts>
-        </weapon>
-    </weapons>
+    <!-- <weapons> Sniper Sized Individual Ranged Weapons -->
+    <!-- Keep this commented until the category is populated -->
+    <!-- </weapons> -->
 
     <!-- House Rules for accessory slots -->
     <accessories>
         <accessory> <!-- Ammo Skip System takes only an Internal slot -->
             <id>0c315fd8-3a1a-4748-8359-cb6a04436fbd</id>
-            <mount amendoperation="replace">Hub Internal</mount>
+            <mount amendoperation="replace">Internal</mount>
         </accessory>
         <accessory> <!-- Electronic Firing needs to use Internal slot and can't be used with certain weapons -->
             <id>2da4f104-cf0c-4e0c-a001-4a6da4c2b46b</id>
-            <mount amendoperation="replace">Hub Internal</mount> <!-- Electronic firing occupies the Internal slot -->
+            <mount amendoperation="replace">Internal</mount> <!-- Electronic firing occupies the Internal slot -->
             <forbidden>
                 <weapondetails amendoperation="addnode"> <!-- Forbid Individual weapons -->
                     <OR> 
@@ -412,18 +244,6 @@
                     </OR>
                 </weapondetails>
             </forbidden>
-        </accessory>
-        <accessory> <!-- Guncam needs to use Hub Internal slot -->
-            <id>9a27efa9-f3f4-4e47-9165-76e8adbad4ba</id>
-            <mount amendoperation="regexreplace" regexpattern="Internal">Hub Internal</mount>
-        </accessory>
-        <accessory> <!-- Improved Range Finder needs to use Hub Internal slot -->
-            <id>21bc8b85-3fd7-4bde-ac8d-35e1fa099f21</id>
-            <mount amendoperation="regexreplace" regexpattern="Internal">Hub Internal</mount>
-        </accessory>
-        <accessory> <!-- Safe Target System, Base needs to use Hub Internal slot -->
-            <id>51740a3d-4464-4a38-8e2e-8858b3c1481e</id>
-            <mount amendoperation="regexreplace" regexpattern="Internal">Hub Internal</mount>
         </accessory>
     </accessories>
 </chummer>

--- a/amend_weapons.xml
+++ b/amend_weapons.xml
@@ -40,7 +40,7 @@
 	</weapons>
 
     <!-- Chummer treats Internal slot as None, so create custom Internal mount and apply to all guns that should have one -->
-    <!-- Also apply mod slots for Individual Weapons -->
+    <!-- Also apply missing mounts for Individual Weapons -->
     <weapons> <!-- Weapon Categories -->
         <weapon xpathfilter="category='Tasers'">
             <accessorymounts>		
@@ -202,14 +202,20 @@
         </weapon>
         <weapon> <!-- Grapple Gun -->
             <id>9c267b03-103e-43f4-bfe8-986c69dc17d2</id>
-            <accessorymounts>		
-                <mount amendoperation="addnode">Hub Internal</mount>
+            <accessorymounts amendoperation="addnode">		
+                <mount>Top</mount>
+                <mount>Side</mount>
+                <mount>Stock</mount>
+                <mount>Hub Internal</mount>
             </accessorymounts>
         </weapon>
         <weapon> <!-- Tactical Grapple Gun -->
             <id>3a60c3ee-9f6f-46cb-be2f-bec0bccc3318</id>
-            <accessorymounts>		
-                <mount amendoperation="addnode">Hub Internal</mount>
+            <accessorymounts amendoperation="addnode">		
+                <mount>Top</mount>
+                <mount>Side</mount>
+                <mount>Stock</mount>
+                <mount>Hub Internal</mount>
             </accessorymounts>
         </weapon>
     </weapons>

--- a/amend_weapons.xml
+++ b/amend_weapons.xml
@@ -175,6 +175,7 @@
         <weapon> <!-- FN-AAL Gyrojet Pistol -->
             <id>a836fc0b-a1e1-491d-ad8d-7f803c88acdc</id>
             <accessorymounts>		
+                <mount amendoperation="addnode">Barrel</mount>
                 <mount amendoperation="addnode">Hub Internal</mount>
             </accessorymounts>
         </weapon>
@@ -314,6 +315,31 @@
         <accessory>
             <id>2da4f104-cf0c-4e0c-a001-4a6da4c2b46b</id> <!-- Electronic firing occupies the Internal slot -->
             <mount amendoperation="replace">Hub Internal</mount>
+            <forbidden>
+                <weapondetails amendoperation="addnode">
+                    <OR> <!-- Forbid Individual weapons -->
+                        <name>Parashield Dart Pistol</name>
+                        <name>The Ares Redline Laser Pistol</name>
+                        <name>The Narcoject Gas Gun</name>
+                        <name>The Narcoject Trackstopper</name>
+                        <name>Ares Lancer MP Laser</name>
+                        <name>Grapple Gun</name>
+                        <name>Tactical Grapple Gun</name>
+                        <name>Ares S-III Super Squirt</name>
+                        <name>Fichetti Pain Inducer</name>
+                        <name>Aquadyne Shark-XS Harpoon Gun</name>
+                        <name>Standard Harpoon Gun</name>
+                        <name>Ares Armatus</name>
+                        <name>Ares Screech Sonic Rifle</name>
+                        <name>Repeating Laser</name>
+                        <name>Microwave Gun, High Frequency</name>
+                        <name>Microwave Gun, Low Frequency</name>
+                        <name>Parashield Dart Rifle</name>
+                        <name>Ares Archon Heavy MP Laser</name>
+                        <name>Ares Thunderstruck Gauss Rifle</name>
+                    </OR>
+                </weapondetails>
+            </forbidden>
         </accessory>
         <accessory>
             <id>0c315fd8-3a1a-4748-8359-cb6a04436fbd</id> <!-- Ammo Skip System takes only an Internal slot -->
@@ -359,6 +385,16 @@
                     </OR>
                 </weapondetails>
             </required>
+        </accessory>
+        <accessory> <!-- Ban Gyroget Pistol from having Suppressor-->
+            <id>0da6149e-982f-4051-825b-52c1b79c7e52</id>
+            <forbidden>
+                <weapondetails>
+                    <OR>
+                        <name amendoperation="addnode">FN-AAL Gyrojet Pistol</name>
+                    </OR>
+                </weapondetails>
+            </forbidden>
         </accessory>
     </accessories>
 </chummer>

--- a/amend_weapons.xml
+++ b/amend_weapons.xml
@@ -347,12 +347,12 @@
             <id>d5abeadd-fba4-47f9-ac35-bfbb31ce34be</id> 
             <mount amendoperation="replace"></mount>
             <forbidden amendoperation="addnode">
-                <oneof>
+                <oneof> <!-- Forbid Shortbarrel and Stock Removal because they are mutex -->
                 <accessory>Sawed Off/Shortbarrel</accessory>
                 <accessory>Sawed Off/Shortbarrel and Stock Removal</accessory>
                 </oneof>
                 <weapondetails>
-                <OR> <!-- Shouldn't be needed but missing from weapons.xml currently -->
+                <OR> <!-- Forbid HK series because long barrel is slotless now -->
                     <name>HK Urban Combat</name>
                     <name>HK Urban Enforcer</name>
                     <name>HK Urban Fighter</name>
@@ -361,13 +361,14 @@
                 </weapondetails>
             </forbidden>
             <required amendoperation="addnode">
-                <weapondetails>
+                <weapondetails> <!--  Explicitly re-add weapons with a barrel slot -->
                     <OR>
                         <category operation="contains">Rifles</category>
                         <category operation="contains">Pistols</category>
                         <category>Shotguns</category>
                         <category operation="contains">Machine Guns</category>
                         <category>Carbines</category>
+                        <name>FN-AAL Gyrojet Pistol</name>
                     </OR>
                 </weapondetails>
             </required>

--- a/amend_weapons.xml
+++ b/amend_weapons.xml
@@ -39,7 +39,8 @@
 		</weapon>		
 	</weapons>
 
-    <!-- Chummer treats Internal slot as None, so create custom Internal mount and apply to all guns that should have one-->
+    <!-- Chummer treats Internal slot as None, so create custom Internal mount and apply to all guns that should have one -->
+    <!-- Also apply mod slots for Individual Weapons -->
     <weapons> <!-- Weapon Categories -->
         <weapon xpathfilter="category='Tasers'">
             <accessorymounts>		
@@ -299,22 +300,13 @@
 
     <!-- House Rules for accessory slots -->
     <accessories>
-        <accessory>
-            <id>0da6149e-982f-4051-825b-52c1b79c7e52</id> <!-- suppressors on shotguns -->
-            <forbidden>
-                <weapondetails>
-                <OR>
-                    <ammocategory amendoperation="remove">Shotguns</ammocategory>
-                    <category amendoperation="remove">Shotguns</category>
-                    <spec amendoperation="remove">Shotguns</spec>
-                    <spec2 amendoperation="remove">Shotguns</spec2>
-                </OR>
-                </weapondetails>
-            </forbidden>
-        </accessory>
-        <accessory>
-            <id>2da4f104-cf0c-4e0c-a001-4a6da4c2b46b</id> <!-- Electronic firing occupies the Internal slot -->
+        <accessory> <!-- Ammo Skip System takes only an Internal slot -->
+            <id>0c315fd8-3a1a-4748-8359-cb6a04436fbd</id>
             <mount amendoperation="replace">Hub Internal</mount>
+        </accessory>
+        <accessory> <!-- Electronic Firing needs to use Internal slot and can't be used with certain weapons -->
+            <id>2da4f104-cf0c-4e0c-a001-4a6da4c2b46b</id>
+            <mount amendoperation="replace">Hub Internal</mount> <!-- Electronic firing occupies the Internal slot -->
             <forbidden>
                 <weapondetails amendoperation="addnode">
                     <OR> <!-- Forbid Individual weapons -->
@@ -341,24 +333,8 @@
                 </weapondetails>
             </forbidden>
         </accessory>
-        <accessory>
-            <id>0c315fd8-3a1a-4748-8359-cb6a04436fbd</id> <!-- Ammo Skip System takes only an Internal slot -->
-            <mount amendoperation="replace">Hub Internal</mount>
-        </accessory>
-        <accessory>
-            <id>9a27efa9-f3f4-4e47-9165-76e8adbad4ba</id> <!-- Guncam needs to use Hub Internal slot -->
-            <mount amendoperation="regexreplace" regexpattern="Internal">Hub Internal</mount>
-        </accessory>
-        <accessory>
-            <id>21bc8b85-3fd7-4bde-ac8d-35e1fa099f21</id> <!-- Improved Range Finder needs to use Hub Internal slot -->
-            <mount amendoperation="regexreplace" regexpattern="Internal">Hub Internal</mount>
-        </accessory>
-        <accessory>
-            <id>51740a3d-4464-4a38-8e2e-8858b3c1481e</id> <!-- Safe Target System, Base needs to use Hub Internal slot -->
-            <mount amendoperation="regexreplace" regexpattern="Internal">Hub Internal</mount>
-        </accessory>
-        <accessory>
-            <id>d5abeadd-fba4-47f9-ac35-bfbb31ce34be</id> <!--  Long Barrel modification takes up no slots -->
+        <accessory> <!--  Long Barrel modification takes up no slots -->
+            <id>d5abeadd-fba4-47f9-ac35-bfbb31ce34be</id> 
             <mount amendoperation="replace"></mount>
             <forbidden amendoperation="addnode">
                 <oneof>
@@ -386,6 +362,19 @@
                 </weapondetails>
             </required>
         </accessory>
+        <accessory> <!-- Shotguns may be modified with Suppressors -->
+            <id>0da6149e-982f-4051-825b-52c1b79c7e52</id>
+            <forbidden>
+                <weapondetails>
+                <OR>
+                    <ammocategory amendoperation="remove">Shotguns</ammocategory>
+                    <category amendoperation="remove">Shotguns</category>
+                    <spec amendoperation="remove">Shotguns</spec>
+                    <spec2 amendoperation="remove">Shotguns</spec2>
+                </OR>
+                </weapondetails>
+            </forbidden>
+        </accessory>
         <accessory> <!-- Ban Gyroget Pistol from having Suppressor-->
             <id>0da6149e-982f-4051-825b-52c1b79c7e52</id>
             <forbidden>
@@ -395,6 +384,18 @@
                     </OR>
                 </weapondetails>
             </forbidden>
+        </accessory>
+        <accessory> <!-- Guncam needs to use Hub Internal slot -->
+            <id>9a27efa9-f3f4-4e47-9165-76e8adbad4ba</id>
+            <mount amendoperation="regexreplace" regexpattern="Internal">Hub Internal</mount>
+        </accessory>
+        <accessory> <!-- Improved Range Finder needs to use Hub Internal slot -->
+            <id>21bc8b85-3fd7-4bde-ac8d-35e1fa099f21</id>
+            <mount amendoperation="regexreplace" regexpattern="Internal">Hub Internal</mount>
+        </accessory>
+        <accessory> <!-- Safe Target System, Base needs to use Hub Internal slot -->
+            <id>51740a3d-4464-4a38-8e2e-8858b3c1481e</id>
+            <mount amendoperation="regexreplace" regexpattern="Internal">Hub Internal</mount>
         </accessory>
     </accessories>
 </chummer>

--- a/amend_weapons.xml
+++ b/amend_weapons.xml
@@ -52,6 +52,10 @@
                 </weapondetails>
             </forbidden>
         </accessory>
+            <accessory>
+                <id>2da4f104-cf0c-4e0c-a001-4a6da4c2b46b</id> <!-- Electronic firing uses internal mount -->
+                <mount amendoperation="replace">Internal</mount>
+            </accessory>
     </accessories>
 </chummer>
 

--- a/amend_weapons.xml
+++ b/amend_weapons.xml
@@ -53,9 +53,13 @@
             </forbidden>
         </accessory>
             <accessory>
-                <id>2da4f104-cf0c-4e0c-a001-4a6da4c2b46b</id> <!-- Electronic firing uses internal mount -->
+                <id>2da4f104-cf0c-4e0c-a001-4a6da4c2b46b</id> <!-- Electronic firing occupies the Internal slot -->
                 <mount amendoperation="replace">Internal</mount>
             </accessory>
-    </accessories>
+            <accessory>
+                <id>0c315fd8-3a1a-4748-8359-cb6a04436fbd</id> <!-- Ammo Skip System takes only an internal slot. -->
+                <mount amendoperation="replace">Internal</mount>
+            </accessory>
+        </accessories>
 </chummer>
 

--- a/amend_weapons.xml
+++ b/amend_weapons.xml
@@ -63,6 +63,20 @@
             <accessory>
                 <id>d5abeadd-fba4-47f9-ac35-bfbb31ce34be</id> <!--  Long Barrel modification takes up no slots -->
                 <mount amendoperation="replace"></mount>
+                <forbidden amendoperation="addnode">
+                    <oneof>
+                    <accessory>Sawed Off/Shortbarrel</accessory>
+                    <accessory>Sawed Off/Shortbarrel and Stock Removal</accessory>
+                    </oneof>
+                    <weapondetails>
+                    <OR> <!-- Shouldn't be needed but missing from weapons.xml currently -->
+                        <name>HK Urban Combat</name>
+                        <name>HK Urban Enforcer</name>
+                        <name>HK Urban Fighter</name>
+                        <name>HK Urban Assassin</name>
+                    </OR>
+                    </weapondetails>
+                </forbidden>
             </accessory>
         </accessories>
 </chummer>

--- a/amend_weapons.xml
+++ b/amend_weapons.xml
@@ -122,6 +122,13 @@
                 <mount amendoperation="addnode">Hub Internal</mount>
             </accessorymounts>
         </weapon>
+        <weapon xpathfilter="category='Flamethrowers'">
+            <accessorymounts amendoperation="replace" addifnotfound="True">
+                <mount>Top</mount>
+                <mount>Side</mount>
+                <mount>Under</mount>
+            </accessorymounts>
+        </weapon>
     </weapons>
     <weapons> <!-- Crossbows -->
         <weapon> <!-- Light Crossbow -->

--- a/amend_weapons.xml
+++ b/amend_weapons.xml
@@ -17,9 +17,9 @@
     You can obtain the full source code for Chummer5a at
     https://github.com/chummer5a/chummer5a
 -->
-<!-- Blah blah cyberweaponizes stuff for WotS. -->
 
 <chummer>
+    <!-- Blah blah cyberweaponizes stuff for WotS. -->
 	<weapons>
 		<weapon>
 			<id>fe835c72-a973-4976-bf5f-751aff1371d4</id> <!-- spurs -->
@@ -38,6 +38,225 @@
 			<category>Cyberweapon</category>
 		</weapon>		
 	</weapons>
+
+    <!-- Chummer treats Internal slot as None, so create custom Internal mount and apply to all guns that should have one-->
+    <weapons> <!-- Weapon Categories -->
+        <weapon xpathfilter="category='Tasers'">
+            <accessorymounts>		
+                <mount amendoperation="addnode">Hub Internal</mount>
+            </accessorymounts>
+        </weapon>
+        <weapon xpathfilter="category='Light Pistols'">
+            <accessorymounts>		
+                <mount amendoperation="addnode">Hub Internal</mount>
+            </accessorymounts>
+        </weapon>
+        <weapon xpathfilter="category='Heavy Pistols'">
+            <accessorymounts>		
+                <mount amendoperation="addnode">Hub Internal</mount>
+            </accessorymounts>
+        </weapon>
+        <weapon xpathfilter="category='Machine Pistols'">
+            <accessorymounts>		
+                <mount amendoperation="addnode">Hub Internal</mount>
+            </accessorymounts>
+        </weapon>
+        <weapon xpathfilter="category='Submachine Guns'">
+            <accessorymounts>		
+                <mount amendoperation="addnode">Hub Internal</mount>
+            </accessorymounts>
+        </weapon>
+        <weapon xpathfilter="category='Assault Rifles'">
+            <accessorymounts>		
+                <mount amendoperation="addnode">Hub Internal</mount>
+            </accessorymounts>
+        </weapon>
+        <weapon xpathfilter="category='Carbines'">
+            <accessorymounts>		
+                <mount amendoperation="addnode">Hub Internal</mount>
+            </accessorymounts>
+        </weapon>
+        <weapon xpathfilter="category='Sporting Rifles'">
+            <accessorymounts>		
+                <mount amendoperation="addnode">Hub Internal</mount>
+            </accessorymounts>
+        </weapon>
+        <weapon xpathfilter="category='Sniper Rifles'">
+            <accessorymounts>		
+                <mount amendoperation="addnode">Hub Internal</mount>
+            </accessorymounts>
+        </weapon>
+        <weapon xpathfilter="category='Shotguns'">
+            <accessorymounts>		
+                <mount amendoperation="addnode">Hub Internal</mount>
+            </accessorymounts>
+        </weapon>
+        <weapon xpathfilter="category='Light Machine Guns'">
+            <accessorymounts>		
+                <mount amendoperation="addnode">Hub Internal</mount>
+            </accessorymounts>
+        </weapon>
+        <weapon xpathfilter="category='Medium Machine Guns'">
+            <accessorymounts>		
+                <mount amendoperation="addnode">Hub Internal</mount>
+            </accessorymounts>
+        </weapon>
+        <weapon xpathfilter="category='Heavy Machine Guns'">
+            <accessorymounts>		
+                <mount amendoperation="addnode">Hub Internal</mount>
+            </accessorymounts>
+        </weapon>
+        <weapon xpathfilter="category='Assault Cannons'">
+            <accessorymounts>		
+                <mount amendoperation="addnode">Hub Internal</mount>
+            </accessorymounts>
+        </weapon>
+        <weapon xpathfilter="category='Grenade Launchers'">
+            <accessorymounts>		
+                <mount amendoperation="addnode">Hub Internal</mount>
+            </accessorymounts>
+        </weapon>
+        <weapon xpathfilter="category='Missile Launchers'">
+            <accessorymounts>		
+                <mount amendoperation="addnode">Hub Internal</mount>
+            </accessorymounts>
+        </weapon>
+        <weapon xpathfilter="category='Crossbows'">
+            <accessorymounts>		
+                <mount amendoperation="addnode">Hub Internal</mount>
+            </accessorymounts>
+        </weapon>
+    </weapons>
+    <weapons> <!-- Pistol Sized Individual Ranged Weapons -->
+        <weapon> <!-- Parashield Dart Pistol -->
+            <id>9c3d9b2e-336e-4c37-b05d-07bea9ae9c3f</id>
+            <accessorymounts>		
+                <mount amendoperation="addnode">Hub Internal</mount>
+            </accessorymounts>
+        </weapon>
+        <weapon> <!-- Ares Redline -->
+            <id>78293136-5bd0-49ac-aa9b-7c291f94c7a4</id>
+            <accessorymounts>		
+                <mount amendoperation="addnode">Hub Internal</mount>
+            </accessorymounts>
+        </weapon>
+        <weapon> <!-- FN-AAL Gyrojet Pistol -->
+            <id>a836fc0b-a1e1-491d-ad8d-7f803c88acdc</id>
+            <accessorymounts>		
+                <mount amendoperation="addnode">Hub Internal</mount>
+            </accessorymounts>
+        </weapon>
+        <weapon> <!-- Narcoject Gas Gun -->
+            <id>39a6ea40-087e-4caa-b5a5-94d7c2a203f3</id>
+            <accessorymounts>		
+                <mount amendoperation="addnode">Hub Internal</mount>
+            </accessorymounts>
+        </weapon>
+        <weapon> <!-- Narcoject Trackstopper -->
+            <id>823ffbe6-b8a9-43f6-91e1-ba3e312ce577</id>
+            <accessorymounts>		
+                <mount amendoperation="addnode">Hub Internal</mount>
+            </accessorymounts>
+        </weapon>
+    </weapons>
+    <weapons> <!-- Submachine Gun Sized Individual Ranged Weapons -->    
+        <weapon> <!-- Ares Lancer MP Laser -->
+            <id>d6c4ff4a-5fbb-4885-9220-a784e2bff4f4</id>
+            <accessorymounts>		
+                <mount amendoperation="addnode">Hub Internal</mount>
+            </accessorymounts>
+        </weapon>
+        <weapon> <!-- Grapple Gun -->
+            <id>9c267b03-103e-43f4-bfe8-986c69dc17d2</id>
+            <accessorymounts>		
+                <mount amendoperation="addnode">Hub Internal</mount>
+            </accessorymounts>
+        </weapon>
+        <weapon> <!-- Tactical Grapple Gun -->
+            <id>3a60c3ee-9f6f-46cb-be2f-bec0bccc3318</id>
+            <accessorymounts>		
+                <mount amendoperation="addnode">Hub Internal</mount>
+            </accessorymounts>
+        </weapon>
+    </weapons>
+    <weapons> <!-- Assault Rifle Sized Individual Ranged Weapons --> 
+        <weapon> <!-- Ares S-III Super Squirt -->
+            <id>15ec7fbb-4c22-4cae-a7cd-d2c580a6b447</id>
+            <accessorymounts>		
+                <mount amendoperation="addnode">Hub Internal</mount>
+            </accessorymounts>
+        </weapon>
+        <weapon> <!-- Fichetti Pain Inducer -->
+            <id>c884cf55-9a96-459d-a764-f223e1853149</id>
+            <accessorymounts>		
+                <mount amendoperation="addnode">Hub Internal</mount>
+            </accessorymounts>
+        </weapon>
+        <weapon> <!-- Aquadyne Shark-XS Harpoon Gun -->
+            <id>a20f44a1-ced0-4018-9522-8a0e7234c29d</id>
+            <accessorymounts>		
+                <mount amendoperation="addnode">Hub Internal</mount>
+            </accessorymounts>
+        </weapon>
+        <weapon> <!-- Standard Harpoon Gun -->
+            <id>d50f0212-490b-44ca-8365-09e62ea69697</id>
+            <accessorymounts>		
+                <mount amendoperation="addnode">Hub Internal</mount>
+            </accessorymounts>
+        </weapon>
+        <weapon> <!-- Ares Armatus -->
+            <id>176ab92a-0c00-48fe-a994-668903407fbf</id>
+            <accessorymounts>		
+                <mount amendoperation="addnode">Hub Internal</mount>
+            </accessorymounts>
+        </weapon>
+        <weapon> <!-- Ares Screech Sonic Rifle -->
+            <id>e85d55b3-06f1-48e0-bbe1-14b833ac4181</id>
+            <accessorymounts>		
+                <mount amendoperation="addnode">Hub Internal</mount>
+            </accessorymounts>
+        </weapon>
+        <weapon> <!-- Repeating Laser -->
+            <id>bb17f788-f4d2-4a32-a758-2ed47a1beb63</id>
+            <accessorymounts>		
+                <mount amendoperation="addnode">Hub Internal</mount>
+            </accessorymounts>
+        </weapon>
+        <weapon> <!-- Microwave Gun, High Frequency -->
+            <id>21fb8d4f-5958-4fd9-996f-7e88ee0282c2</id>
+            <accessorymounts>		
+                <mount amendoperation="addnode">Hub Internal</mount>
+            </accessorymounts>
+        </weapon>
+        <weapon> <!-- Microwave Gun, Low Frequency -->
+            <id>10fb69db-efd0-4f63-80a7-bda5ef0480a4</id>
+            <accessorymounts>		
+                <mount amendoperation="addnode">Hub Internal</mount>
+            </accessorymounts>
+        </weapon>
+    </weapons>
+    <weapons> <!-- Sniper Sized Individual Ranged Weapons -->
+        <weapon> <!-- Parashield Dart Rifle -->
+            <id>8432b006-0496-4930-b966-25ab56feb7e2</id>
+            <accessorymounts>		
+                <mount amendoperation="addnode">Hub Internal</mount>
+            </accessorymounts>
+        </weapon>
+        <weapon> <!-- Ares Archon Heavy MP Laser -->
+            <id>df5d5c83-ddf8-4ec2-8a6f-28c61ec7325a</id>
+            <accessorymounts>		
+                <mount amendoperation="addnode">Hub Internal</mount>
+            </accessorymounts>
+        </weapon>
+        <weapon> <!-- Ares Thunderstruck Gauss Rifle -->
+            <id>e5ac06f4-3755-42a7-9da9-88de4b3b2ad8</id>
+            <accessorymounts>		
+                <mount amendoperation="addnode">Hub Internal</mount>
+            </accessorymounts>
+        </weapon>
+    </weapons>
+
+    <!-- House Rules for accessory slots -->
     <accessories>
         <accessory>
             <id>0da6149e-982f-4051-825b-52c1b79c7e52</id> <!-- suppressors on shotguns -->
@@ -52,43 +271,55 @@
                 </weapondetails>
             </forbidden>
         </accessory>
-            <accessory>
-                <id>2da4f104-cf0c-4e0c-a001-4a6da4c2b46b</id> <!-- Electronic firing occupies the Internal slot -->
-                <mount amendoperation="replace">Internal</mount>
-            </accessory>
-            <accessory>
-                <id>0c315fd8-3a1a-4748-8359-cb6a04436fbd</id> <!-- Ammo Skip System takes only an Internal slot -->
-                <mount amendoperation="replace">Internal</mount>
-            </accessory>
-            <accessory>
-                <id>d5abeadd-fba4-47f9-ac35-bfbb31ce34be</id> <!--  Long Barrel modification takes up no slots -->
-                <mount amendoperation="replace"></mount>
-                <forbidden amendoperation="addnode">
-                    <oneof>
-                    <accessory>Sawed Off/Shortbarrel</accessory>
-                    <accessory>Sawed Off/Shortbarrel and Stock Removal</accessory>
-                    </oneof>
-                    <weapondetails>
-                    <OR> <!-- Shouldn't be needed but missing from weapons.xml currently -->
-                        <name>HK Urban Combat</name>
-                        <name>HK Urban Enforcer</name>
-                        <name>HK Urban Fighter</name>
-                        <name>HK Urban Assassin</name>
+        <accessory>
+            <id>2da4f104-cf0c-4e0c-a001-4a6da4c2b46b</id> <!-- Electronic firing occupies the Internal slot -->
+            <mount amendoperation="replace">Hub Internal</mount>
+        </accessory>
+        <accessory>
+            <id>0c315fd8-3a1a-4748-8359-cb6a04436fbd</id> <!-- Ammo Skip System takes only an Internal slot -->
+            <mount amendoperation="replace">Hub Internal</mount>
+        </accessory>
+        <accessory>
+            <id>9a27efa9-f3f4-4e47-9165-76e8adbad4ba</id> <!-- Guncam needs to use Hub Internal slot -->
+            <mount amendoperation="regexreplace" regexpattern="Internal">Hub Internal</mount>
+        </accessory>
+        <accessory>
+            <id>21bc8b85-3fd7-4bde-ac8d-35e1fa099f21</id> <!-- Improved Range Finder needs to use Hub Internal slot -->
+            <mount amendoperation="regexreplace" regexpattern="Internal">Hub Internal</mount>
+        </accessory>
+        <accessory>
+            <id>51740a3d-4464-4a38-8e2e-8858b3c1481e</id> <!-- Safe Target System, Base needs to use Hub Internal slot -->
+            <mount amendoperation="regexreplace" regexpattern="Internal">Hub Internal</mount>
+        </accessory>
+        <accessory>
+            <id>d5abeadd-fba4-47f9-ac35-bfbb31ce34be</id> <!--  Long Barrel modification takes up no slots -->
+            <mount amendoperation="replace"></mount>
+            <forbidden amendoperation="addnode">
+                <oneof>
+                <accessory>Sawed Off/Shortbarrel</accessory>
+                <accessory>Sawed Off/Shortbarrel and Stock Removal</accessory>
+                </oneof>
+                <weapondetails>
+                <OR> <!-- Shouldn't be needed but missing from weapons.xml currently -->
+                    <name>HK Urban Combat</name>
+                    <name>HK Urban Enforcer</name>
+                    <name>HK Urban Fighter</name>
+                    <name>HK Urban Assassin</name>
+                </OR>
+                </weapondetails>
+            </forbidden>
+            <required amendoperation="addnode">
+                <weapondetails>
+                    <OR>
+                        <category operation="contains">Rifles</category>
+                        <category operation="contains">Pistols</category>
+                        <category>Shotguns</category>
+                        <category operation="contains">Machine Guns</category>
+                        <category>Carbines</category>
                     </OR>
-                    </weapondetails>
-                </forbidden>
-                <required amendoperation="addnode">
-                    <weapondetails>
-                        <OR>
-                            <category operation="contains">Rifles</category>
-                            <category operation="contains">Pistols</category>
-                            <category>Shotguns</category>
-                            <category operation="contains">Machine Guns</category>
-                            <category>Carbines</category>
-                        </OR>
-                    </weapondetails>
-                </required>
-            </accessory>
-        </accessories>
+                </weapondetails>
+            </required>
+        </accessory>
+    </accessories>
 </chummer>
 

--- a/amend_weapons.xml
+++ b/amend_weapons.xml
@@ -308,12 +308,16 @@
             <id>2da4f104-cf0c-4e0c-a001-4a6da4c2b46b</id>
             <mount amendoperation="replace">Hub Internal</mount> <!-- Electronic firing occupies the Internal slot -->
             <forbidden>
-                <weapondetails amendoperation="addnode">
-                    <OR> <!-- Forbid Individual weapons -->
+                <weapondetails amendoperation="addnode"> <!-- Forbid Individual weapons -->
+                    <OR> 
+                        <name>Light Crossbow</name>
+                        <name>Medium Crossbow</name>
+                        <name>Heavy Crossbow</name>
+                        <name>Ranger Sliver Pistol Crossbow</name>
                         <name>Parashield Dart Pistol</name>
-                        <name>The Ares Redline Laser Pistol</name>
-                        <name>The Narcoject Gas Gun</name>
-                        <name>The Narcoject Trackstopper</name>
+                        <name>Ares Redline</name>
+                        <name>Narcoject Gas Gun</name>
+                        <name>Narcoject Trackstopper</name>
                         <name>Ares Lancer MP Laser</name>
                         <name>Grapple Gun</name>
                         <name>Tactical Grapple Gun</name>

--- a/amend_weapons.xml
+++ b/amend_weapons.xml
@@ -57,8 +57,12 @@
                 <mount amendoperation="replace">Internal</mount>
             </accessory>
             <accessory>
-                <id>0c315fd8-3a1a-4748-8359-cb6a04436fbd</id> <!-- Ammo Skip System takes only an internal slot. -->
+                <id>0c315fd8-3a1a-4748-8359-cb6a04436fbd</id> <!-- Ammo Skip System takes only an Internal slot -->
                 <mount amendoperation="replace">Internal</mount>
+            </accessory>
+            <accessory>
+                <id>d5abeadd-fba4-47f9-ac35-bfbb31ce34be</id> <!--  Long Barrel modification takes up no slots -->
+                <mount amendoperation="replace"></mount>
             </accessory>
         </accessories>
 </chummer>

--- a/amend_weapons.xml
+++ b/amend_weapons.xml
@@ -77,6 +77,17 @@
                     </OR>
                     </weapondetails>
                 </forbidden>
+                <required amendoperation="addnode">
+                    <weapondetails>
+                        <OR>
+                            <category operation="contains">Rifles</category>
+                            <category operation="contains">Pistols</category>
+                            <category>Shotguns</category>
+                            <category operation="contains">Machine Guns</category>
+                            <category>Carbines</category>
+                        </OR>
+                    </weapondetails>
+                </required>
             </accessory>
         </accessories>
 </chummer>


### PR DESCRIPTION
## High Level Description
Implement amends for [Weapon Modifications](https://runnerhub.neosynth.net/index.php?n=Rules.Gear#toc-1.7). 

## Summary of changes
  * Add new mount to all guns with Internal mount called "Hub Internal" (workaround for Chummer not treating Internal mounts properly)
  * Add hub mounts to Flamethrowers category
  * Add hub mounts to Grapple Guns
  * Add hub mounts to Microwave Guns
  * FN-AAL Gyrojet Pistol has access to the Barrel slot and Electronic Firing, but not Suppressors
  * Ammo skip now takes only an internal mount
  * Electronic firing now occupies the internal mount (with exceptions for individual ranged weapons)
  * Long barrel HRAW
  
 ## Process
I started out initially planning to only implement the Specific Weapon Modifications. However, in order to do so I found that Chummer treats an Internal mount and None mount as the same thing. To make Chummer behave as HRAW, a custom mount was needed. In the process of adding this custom mount to every gun that has an Internal mount per HRAW, I found a few weapons that had no mounts, and had to add tags accordingly. However, confirming all weapon slots are correct, overwriting incorrect concealability, confirming PEPs, confirming Airbow, and disallowing the modifications for melee and excluded individual ranged weapons was out of scope for this PR.

## Validation
Test Plan on [Google Sheets](https://docs.google.com/spreadsheets/d/1qQIqRJx-WhXSlS9J2zAAS-Q-X13S5yTWvqvOaPdfUx4/edit?usp=sharing). Not complete coverage, as that would require me to check every gun in the game, but it covers enough that I am confident in my work.

The one fail listed is an automation issue in Chummer. ***TL;DR, only new guns and weapon mods will have the changes. This is based on how Chummer works and not something that can be fixed in XML, so anyone updating their amend files will need to re-add any guns that were affected (which is most of them).***

## Contact
`_ponpon` on Discord.